### PR TITLE
升级目标框架和多个包版本

### DIFF
--- a/Infrastructure/ZR.Infrastructure.csproj
+++ b/Infrastructure/ZR.Infrastructure.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<NoWarn>8632</NoWarn>
@@ -12,12 +12,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="AspectCore.Abstractions" Version="2.4.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="UAParser" Version="3.1.47" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
 		<PackageReference Include="JinianNet.JNTemplate" Version="2.4.2" />
-		<PackageReference Include="MiniExcel" Version="1.32.1" />
+		<PackageReference Include="MiniExcel" Version="1.34.2" />
 		<PackageReference Include="CSRedisCore" Version="3.8.803" />
 		<PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
 		<PackageReference Include="IP2Region.Net" Version="2.0.2" />

--- a/ZR.Admin.WebApi/ZR.Admin.WebApi.csproj
+++ b/ZR.Admin.WebApi/ZR.Admin.WebApi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -17,13 +17,19 @@
 		<ProjectReference Include="..\ZR.Tasks\ZR.Tasks.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Lazy.Captcha.Core" Version="2.0.7" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.12" />
-		<PackageReference Include="NLog.Web.AspNetCore" Version="5.3.11" />
+		<PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+		<PackageReference Include="Lazy.Captcha.Core" Version="2.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+		<PackageReference Include="MimeKit" Version="4.8.0" />
+		<PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.170" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
+		<PackageReference Include="NLog.Web.AspNetCore" Version="5.3.14" />
 		<PackageReference Include="Mapster" Version="7.4.0" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ZR.CodeGenerator/ZR.CodeGenerator.csproj
+++ b/ZR.CodeGenerator/ZR.CodeGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -11,7 +11,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
 		<PackageReference Include="JinianNet.JNTemplate" Version="2.4.2" />
-		<PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.157" />
+		<PackageReference Include="MimeKit" Version="4.8.0" />
+		<PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.170" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 </Project>

--- a/ZR.Common/ZR.Common.csproj
+++ b/ZR.Common/ZR.Common.csproj
@@ -1,13 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.13.0" />
-		<PackageReference Include="MailKit" Version="4.3.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.19" />
+		<PackageReference Include="Aliyun.OSS.SDK.NetCore" Version="2.14.1" />
+		<PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+		<PackageReference Include="MailKit" Version="4.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+		<PackageReference Include="MimeKit" Version="4.8.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ZR.Model/ZR.Model.csproj
+++ b/ZR.Model/ZR.Model.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1701;1702;1591;1570</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MiniExcel" Version="1.32.1" />
+		<PackageReference Include="MiniExcel" Version="1.34.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.157" />
+		<PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.170" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 </Project>

--- a/ZR.Repository/ZR.Repository.csproj
+++ b/ZR.Repository/ZR.Repository.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -13,6 +13,7 @@
 		<PackageReference Include="Mapster" Version="7.4.0" />
 		<PackageReference Include="MySqlConnector" Version="2.3.7" />
 		<PackageReference Include="SqlSugar.IOC" Version="2.0.0" />
-		<PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.157" />
+		<PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.170" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 </Project>

--- a/ZR.Service/ZR.Service.csproj
+++ b/ZR.Service/ZR.Service.csproj
@@ -1,13 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<NoWarn>1591</NoWarn>
 	</PropertyGroup>
+	<ItemGroup>
+	  <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+	  <PackageReference Include="MimeKit" Version="4.8.0" />
+	  <PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.170" />
+	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+	  <PackageReference Include="System.Text.Json" Version="8.0.5" />
+	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\ZR.ServiceCore\ZR.ServiceCore.csproj" />
 	</ItemGroup>

--- a/ZR.ServiceCore/ZR.ServiceCore.csproj
+++ b/ZR.ServiceCore/ZR.ServiceCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1701;1702;1591;1570</NoWarn>
@@ -13,8 +13,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+		<PackageReference Include="MimeKit" Version="4.8.0" />
 		<PackageReference Include="NETCore.Encrypt" Version="2.1.1" />
-		<PackageReference Include="NLog" Version="5.3.2" />
+		<PackageReference Include="NLog" Version="5.3.4" />
+		<PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.170" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 
 </Project>

--- a/ZR.Tasks/ZR.Tasks.csproj
+++ b/ZR.Tasks/ZR.Tasks.csproj
@@ -1,13 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.3.2" />
-    <PackageReference Include="Quartz" Version="3.9.0" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+    <PackageReference Include="MimeKit" Version="4.8.0" />
+    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="Quartz" Version="3.13.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.13.1" />
+    <PackageReference Include="SqlSugarCoreNoDrive" Version="5.1.4.170" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
将所有项目的目标框架从 net7.0 升级到 net8.0。
在多个项目中升级了多个包版本，包括：
- Microsoft.Extensions.DependencyModel 到 8.0.2
- Microsoft.AspNetCore.Authentication.JwtBearer 到 8.0.10
- MiniExcel 到 1.34.2
- Lazy.Captcha.Core 到 2.0.9
- Swashbuckle.AspNetCore 到 6.9.0
- NLog 到 5.3.4
- Quartz 到 3.13.1
- Aliyun.OSS.SDK.NetCore 到 2.14.1
- MailKit 到 4.8.0
- Microsoft.AspNetCore.Mvc.NewtonsoftJson 到 8.0.10

添加了以下新包：
- System.IdentityModel.Tokens.Jwt 版本 8.2.0
- System.Text.Json 版本 8.0.5
- BouncyCastle.Cryptography 版本 2.4.0
- MimeKit 版本 4.8.0
- SqlSugarCoreNoDrive 版本 5.1.4.170
- Microsoft.Extensions.Caching.Memory 版本 8.0.1